### PR TITLE
refactor: replace String type with MessageType enum in message DTOs

### DIFF
--- a/im-sdk-core/src/integration-test/java/com/easemob/im/server/api/message/MessageIT.java
+++ b/im-sdk-core/src/integration-test/java/com/easemob/im/server/api/message/MessageIT.java
@@ -1240,7 +1240,7 @@ public class MessageIT extends AbstractIT {
         String messageId = messageIds.getMessageIdsByEntityId().get(randomToUsername);
 
         NewMessage newMessage = NewMessage.builder()
-                .type("txt")
+                .type(MessageType.TXT)
                 .msg("hello world")
                 .build();
 
@@ -1282,7 +1282,7 @@ public class MessageIT extends AbstractIT {
         customExts.put("customKey", "customValue");
 
         NewMessage newMessage = NewMessage.builder()
-                .type("custom")
+                .type(MessageType.CUSTOM)
                 .customEvent("custom_event")
                 .customExts(customExts)
                 .build();

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/MessageApi.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/MessageApi.java
@@ -1532,7 +1532,7 @@ public class MessageApi {
      * EMService service;
      * try {
      *     NewMessage newMessage = NewMessage.builder()
-     *             .type("txt")
+     *             .type(MessageType.TXT)
      *             .msg("hello world")
      *             .build();
      *

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/MessageType.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/MessageType.java
@@ -1,0 +1,39 @@
+package com.easemob.im.server.api.message;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MessageType {
+
+    TXT("txt"),
+    TEXT("text"),
+    IMG("img"),
+    AUDIO("audio"),
+    VIDEO("video"),
+    LOC("loc"),
+    FILE("file"),
+    CMD("cmd"),
+    CUSTOM("custom");
+
+    private final String value;
+
+    MessageType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return this.value;
+    }
+
+    @JsonCreator
+    public static MessageType from(String value) {
+        for (MessageType t : values()) {
+            if (t.value.equals(value)) {
+                return t;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Unknown message type '%s'", value));
+    }
+
+}

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/modify/NewMessage.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/modify/NewMessage.java
@@ -1,5 +1,6 @@
 package com.easemob.im.server.api.message.modify;
 
+import com.easemob.im.server.api.message.MessageType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -9,7 +10,7 @@ import java.util.Map;
 public class NewMessage {
 
     @JsonProperty("type")
-    private String type;
+    private MessageType type;
 
     @JsonProperty("msg")
     private String msg;
@@ -28,7 +29,7 @@ public class NewMessage {
     }
 
     public static class Builder {
-        private String type;
+        private MessageType type;
 
         private String msg;
 
@@ -36,8 +37,17 @@ public class NewMessage {
 
         private Map<String, String> customExts;
 
-        public NewMessage.Builder type(String type) {
+        public NewMessage.Builder type(MessageType type) {
             this.type = type;
+            return this;
+        }
+
+        /**
+         * @deprecated use {@link #type(MessageType)} instead
+         */
+        @Deprecated
+        public NewMessage.Builder type(String type) {
+            this.type = MessageType.from(type);
             return this;
         }
 

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/send/SendChatroomMessageRequest.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/send/SendChatroomMessageRequest.java
@@ -1,5 +1,6 @@
 package com.easemob.im.server.api.message.send;
 
+import com.easemob.im.server.api.message.MessageType;
 import com.easemob.im.server.model.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -136,7 +137,7 @@ public class SendChatroomMessageRequest {
 
     static class Message {
         @JsonProperty("type")
-        private String type;
+        private MessageType type;
 
         @JsonProperty("msg")
         private String text;
@@ -187,7 +188,7 @@ public class SendChatroomMessageRequest {
         private Map<String, Object> customExtensions;
 
         @JsonCreator
-        public Message(@JsonProperty("type") String type,
+        public Message(@JsonProperty("type") MessageType type,
                 @JsonProperty("msg") String text,
                 @JsonProperty("lng") Double longitude,
                 @JsonProperty("lat") Double latitude,
@@ -219,8 +220,16 @@ public class SendChatroomMessageRequest {
             this.customExtensions = customExtensions;
         }
 
-        public Message(String type) {
+        public Message(MessageType type) {
             this.type = type;
+        }
+
+        /**
+         * @deprecated use {@link #Message(MessageType)} instead
+         */
+        @Deprecated
+        public Message(String type) {
+            this(MessageType.from(type));
         }
 
         @SuppressWarnings("unchecked")
@@ -249,13 +258,13 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMTextMessage msg) {
-            Message send = new Message("text");
+            Message send = new Message(MessageType.TEXT);
             send.text = msg.text();
             return send;
         }
 
         public static Message of(EMImageMessage msg) {
-            Message send = new Message("img");
+            Message send = new Message(MessageType.IMG);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -267,7 +276,7 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMVoiceMessage msg) {
-            Message send = new Message("audio");
+            Message send = new Message(MessageType.AUDIO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -277,7 +286,7 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMVideoMessage msg) {
-            Message send = new Message("video");
+            Message send = new Message(MessageType.VIDEO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -289,7 +298,7 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMLocationMessage msg) {
-            Message send = new Message("loc");
+            Message send = new Message(MessageType.LOC);
             send.longitude = msg.longitude();
             send.latitude = msg.latitude();
             send.address = msg.address();
@@ -297,7 +306,7 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMFileMessage msg) {
-            Message send = new Message("file");
+            Message send = new Message(MessageType.FILE);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -306,7 +315,7 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMCommandMessage msg) {
-            Message send = new Message("cmd");
+            Message send = new Message(MessageType.CMD);
             send.action = msg.action();
             if (msg.params() == null) {
                 return send;
@@ -344,7 +353,7 @@ public class SendChatroomMessageRequest {
         }
 
         public static Message of(EMCustomMessage msg) {
-            Message send = new Message("custom");
+            Message send = new Message(MessageType.CUSTOM);
             send.customEvent = msg.customEvent();
             if (msg.customExtensions() == null) {
                 return send;

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/send/SendMessageRequest.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/send/SendMessageRequest.java
@@ -1,6 +1,7 @@
 package com.easemob.im.server.api.message.send;
 
 import com.easemob.im.server.api.message.ChatroomMsgLevel;
+import com.easemob.im.server.api.message.MessageType;
 import com.easemob.im.server.model.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -209,7 +210,7 @@ public class SendMessageRequest {
 
     static class Message {
         @JsonProperty("type")
-        private String type;
+        private MessageType type;
 
         @JsonProperty("msg")
         private String text;
@@ -260,7 +261,7 @@ public class SendMessageRequest {
         private Map<String, Object> customExtensions;
 
         @JsonCreator
-        public Message(@JsonProperty("type") String type,
+        public Message(@JsonProperty("type") MessageType type,
                 @JsonProperty("msg") String text,
                 @JsonProperty("lng") Double longitude,
                 @JsonProperty("lat") Double latitude,
@@ -292,8 +293,16 @@ public class SendMessageRequest {
             this.customExtensions = customExtensions;
         }
 
-        public Message(String type) {
+        public Message(MessageType type) {
             this.type = type;
+        }
+
+        /**
+         * @deprecated use {@link #Message(MessageType)} instead
+         */
+        @Deprecated
+        public Message(String type) {
+            this(MessageType.from(type));
         }
 
         @SuppressWarnings("unchecked")
@@ -322,13 +331,13 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMTextMessage msg) {
-            Message send = new Message("txt");
+            Message send = new Message(MessageType.TXT);
             send.text = msg.text();
             return send;
         }
 
         public static Message of(EMImageMessage msg) {
-            Message send = new Message("img");
+            Message send = new Message(MessageType.IMG);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -340,7 +349,7 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMVoiceMessage msg) {
-            Message send = new Message("audio");
+            Message send = new Message(MessageType.AUDIO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -350,7 +359,7 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMVideoMessage msg) {
-            Message send = new Message("video");
+            Message send = new Message(MessageType.VIDEO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -362,7 +371,7 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMLocationMessage msg) {
-            Message send = new Message("loc");
+            Message send = new Message(MessageType.LOC);
             send.longitude = msg.longitude();
             send.latitude = msg.latitude();
             send.address = msg.address();
@@ -370,7 +379,7 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMFileMessage msg) {
-            Message send = new Message("file");
+            Message send = new Message(MessageType.FILE);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -379,7 +388,7 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMCommandMessage msg) {
-            Message send = new Message("cmd");
+            Message send = new Message(MessageType.CMD);
             send.action = msg.action();
             if (msg.params() == null) {
                 return send;
@@ -417,7 +426,7 @@ public class SendMessageRequest {
         }
 
         public static Message of(EMCustomMessage msg) {
-            Message send = new Message("custom");
+            Message send = new Message(MessageType.CUSTOM);
             send.customEvent = msg.customEvent();
             if (msg.customExtensions() == null) {
                 return send;

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/send/message/MessageSendRequest.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/send/message/MessageSendRequest.java
@@ -1,6 +1,7 @@
 package com.easemob.im.server.api.message.send.message;
 
 import com.easemob.im.server.api.message.ChatroomMsgLevel;
+import com.easemob.im.server.api.message.MessageType;
 import com.easemob.im.server.model.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +20,7 @@ public class MessageSendRequest {
     private String from;
 
     @JsonProperty("type")
-    private String msgType;
+    private MessageType msgType;
 
     /* the server side does not preserve order of targets */
     @JsonProperty("to")
@@ -254,8 +255,16 @@ public class MessageSendRequest {
         return this.tos;
     }
 
-    public String getMsgType(){
+    public MessageType getMsgType(){
         return this.msgType;
+    }
+
+    /**
+     * @deprecated use {@link #getMsgType()} and {@link MessageType#getValue()} instead
+     */
+    @Deprecated
+    public String getMsgTypeAsString(){
+        return this.msgType == null ? null : this.msgType.getValue();
     }
 
     public Message getBody() {
@@ -310,7 +319,7 @@ public class MessageSendRequest {
     static class Message {
 
         @JsonIgnore
-        private String type;
+        private MessageType type;
 
         @JsonProperty("msg")
         private String text;
@@ -376,7 +385,7 @@ public class MessageSendRequest {
                 @JsonProperty("size") MessageSendRequest.Dimensions dimensions,
                 @JsonProperty("customEvent") String customEvent,
                 @JsonProperty("customExts") Map<String, Object> customExtensions) {
-            this.type = type;
+            this.type = type == null ? null : MessageType.from(type);
             this.text = text;
             this.longitude = longitude;
             this.latitude = latitude;
@@ -393,8 +402,16 @@ public class MessageSendRequest {
             this.customExtensions = customExtensions;
         }
 
-        public Message(String type) {
+        public Message(MessageType type) {
             this.type = type;
+        }
+
+        /**
+         * @deprecated use {@link #Message(MessageType)} instead
+         */
+        @Deprecated
+        public Message(String type) {
+            this(MessageType.from(type));
         }
 
         @SuppressWarnings("unchecked")
@@ -423,13 +440,13 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMTextMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("txt");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.TXT);
             send.text = msg.text();
             return send;
         }
 
         public static MessageSendRequest.Message of(EMImageMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("img");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.IMG);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -441,7 +458,7 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMVoiceMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("audio");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.AUDIO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -451,7 +468,7 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMVideoMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("video");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.VIDEO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -463,7 +480,7 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMLocationMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("loc");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.LOC);
             send.longitude = msg.longitude();
             send.latitude = msg.latitude();
             send.address = msg.address();
@@ -471,7 +488,7 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMFileMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("file");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.FILE);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -480,7 +497,7 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMCommandMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("cmd");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.CMD);
             send.action = msg.action();
             if (msg.params() == null) {
                 return send;
@@ -518,7 +535,7 @@ public class MessageSendRequest {
         }
 
         public static MessageSendRequest.Message of(EMCustomMessage msg) {
-            MessageSendRequest.Message send = new MessageSendRequest.Message("custom");
+            MessageSendRequest.Message send = new MessageSendRequest.Message(MessageType.CUSTOM);
             send.customEvent = msg.customEvent();
             if (msg.customExtensions() == null) {
                 return send;

--- a/im-sdk-core/src/main/java/com/easemob/im/server/api/message/upload/ImportMessageRequest.java
+++ b/im-sdk-core/src/main/java/com/easemob/im/server/api/message/upload/ImportMessageRequest.java
@@ -1,5 +1,6 @@
 package com.easemob.im.server.api.message.upload;
 
+import com.easemob.im.server.api.message.MessageType;
 import com.easemob.im.server.model.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -148,7 +149,7 @@ public class ImportMessageRequest {
 
     static class Message {
         @JsonProperty("type")
-        private String type;
+        private MessageType type;
 
         @JsonProperty("msg")
         private String text;
@@ -199,7 +200,7 @@ public class ImportMessageRequest {
         private Map<String, Object> customExtensions;
 
         @JsonCreator
-        public Message(@JsonProperty("type") String type,
+        public Message(@JsonProperty("type") MessageType type,
                 @JsonProperty("msg") String text,
                 @JsonProperty("lng") Double longitude,
                 @JsonProperty("lat") Double latitude,
@@ -231,8 +232,16 @@ public class ImportMessageRequest {
             this.customExtensions = customExtensions;
         }
 
-        public Message(String type) {
+        public Message(MessageType type) {
             this.type = type;
+        }
+
+        /**
+         * @deprecated use {@link #Message(MessageType)} instead
+         */
+        @Deprecated
+        public Message(String type) {
+            this(MessageType.from(type));
         }
 
         @SuppressWarnings("unchecked")
@@ -261,13 +270,13 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMTextMessage msg) {
-            Message send = new Message("text");
+            Message send = new Message(MessageType.TEXT);
             send.text = msg.text();
             return send;
         }
 
         public static Message of(EMImageMessage msg) {
-            Message send = new Message("img");
+            Message send = new Message(MessageType.IMG);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -279,7 +288,7 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMVoiceMessage msg) {
-            Message send = new Message("audio");
+            Message send = new Message(MessageType.AUDIO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -289,7 +298,7 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMVideoMessage msg) {
-            Message send = new Message("video");
+            Message send = new Message(MessageType.VIDEO);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -301,7 +310,7 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMLocationMessage msg) {
-            Message send = new Message("loc");
+            Message send = new Message(MessageType.LOC);
             send.longitude = msg.longitude();
             send.latitude = msg.latitude();
             send.address = msg.address();
@@ -309,7 +318,7 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMFileMessage msg) {
-            Message send = new Message("file");
+            Message send = new Message(MessageType.FILE);
             send.uri = msg.uri() == null ? null : msg.uri().toString();
             send.displayName = msg.displayName();
             send.bytes = msg.bytes();
@@ -318,7 +327,7 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMCommandMessage msg) {
-            Message send = new Message("cmd");
+            Message send = new Message(MessageType.CMD);
             send.action = msg.action();
             if (msg.params() == null) {
                 return send;
@@ -356,7 +365,7 @@ public class ImportMessageRequest {
         }
 
         public static Message of(EMCustomMessage msg) {
-            Message send = new Message("custom");
+            Message send = new Message(MessageType.CUSTOM);
             send.customEvent = msg.customEvent();
             if (msg.customExtensions() == null) {
                 return send;


### PR DESCRIPTION
Replace the String type field/constructor with a new MessageType enum across all message request DTOs.

- New enum MessageType in api/message package with @JsonValue/@JsonCreator for wire-format serialization
- Backward compatible: old Message(String) constructors and Builder.type(String) kept as @Deprecated, delegating to MessageType.from(String)
- No change to JSON output - enum serializes to the same string values (txt, img, audio, etc.)

Files changed:
- api/message/MessageType.java (new enum)
- send/SendMessageRequest.java
- send/message/MessageSendRequest.java
- send/SendChatroomMessageRequest.java
- upload/ImportMessageRequest.java
- modify/NewMessage.java
